### PR TITLE
lease_server reconnect bug

### DIFF
--- a/src/eetcd_lease_server.erl
+++ b/src/eetcd_lease_server.erl
@@ -63,12 +63,12 @@ handle_info({gun_error, Pid, StreamRef, Reason}, State = #state{pid = Pid}) ->
     error_logger:warning_msg("Leaser({~p,~p}) need reconnect gun_error ~p~n state~p~n",
         [?MODULE, self(), {StreamRef, Reason}, State]),
     io:format("gun_error ~p~n", [eetcd_http2_keeper:get_http2_client_pid()]),
-    {noreply, State};
+    reconnect(State);
 handle_info({gun_error, Pid, Reason}, State = #state{pid = Pid}) ->
     error_logger:warning_msg("Leaser({~p,~p}) need reconnect gun_error ~p~n state~p~n",
         [?MODULE, self(), Reason, State]),
     io:format("gun_error ~p~n", [eetcd_http2_keeper:get_http2_client_pid()]),
-    {noreply, State};
+    reconnect(State);
 
 handle_info(Info, State) ->
     error_logger:warning_msg("Leaser({~p,~p}) receive unknow msg ~p~n state~p~n",


### PR DESCRIPTION
I'm testing eetcd and going to use eetcd in product. It seem to exist more bugs and i'm working on them. Please contact me if you wish, my email is enjolras1205@gmail.com, we can communication by wechat in chinese more efficiently. 

erlang version:
Erlang/OTP 21 [erts-10.3.5.6]

i'm not famliar with erlang and i can't run unit test successfully.
rebar3 ct failed as below(the ct.latest.log is the same as verbose), can you tell me why?
~/xxxxx/eetcd(master) » rebar3 ct --verbose                                                                                                                           xxxxx@ubuntu
===> Verifying dependencies...
===> Compiling eetcd
===> Running Common Test suites...

Common Test starting (cwd is /home/xxxxxx/eetcd)

----------------------------------------------------
Suite Callback 2019-12-26 15:46:14.704
Failed to start CTH, see the CT Log for details

Updating /home/xxxxx/eetcd/_build/test/logs/all_runs.html ... done
===> Error running tests:
  "Failed to start CTH, see the CT Log for details"