### PR TITLE
Don't fail if server doesn't support grpc.health.v1.Health

### DIFF
--- a/src/eetcd_conn.erl
+++ b/src/eetcd_conn.erl
@@ -413,6 +413,9 @@ check_health_remote(Gun) ->
     case eetcd_stream:unary(Gun, #{}, 'Etcd.HealthCheckRequest', Path, 'Etcd.HealthCheckResponse', ?HEADERS) of
         {ok, #{status := 'SERVING'}} -> ok;
         {ok, #{status := 'UNKNOWN'}} -> ok;
+        %% etcd does not support health checks in early versions of v3 API
+        {error, {grpc_error, #{'grpc-message' := <<"unknown service grpc.health.v1.Health">>,
+                               'grpc-status'  := ?GRPC_STATUS_UNIMPLEMENTED}}} -> ok;
         {ok, #{status := Status}} -> {error, {unhealthy, Status}};
         {error, _Reason} = Err -> Err
     end.


### PR DESCRIPTION
Apparently that service got added only in 3.3.0.

NB: I have not spent a great amount of time reading the code around health checking, so please let me know if there are scenarios where this will break in a horrible way.