### PR TITLE
Make eetcd_lease_SUITE idempotent

### DIFF
--- a/test/eetcd_kv_SUITE.erl
+++ b/test/eetcd_kv_SUITE.erl
@@ -4,9 +4,9 @@
 
 -export([put/1, range/1, delete_range/1, txn/1, compact/1]).
 
--define(KEY(K), <<"eetcd_kev", (list_to_binary(K))/binary>>).
+-define(KEY(K), <<"eetcd_key_", (list_to_binary(K))/binary>>).
 
--define(VALUE(V), <<"eetcd_value", (list_to_binary(V))/binary>>).
+-define(VALUE(V), <<"eetcd_value_", (list_to_binary(V))/binary>>).
 
 -define(NAME(C), proplists:get_value(name, C)).
 

--- a/test/eetcd_lease_SUITE.erl
+++ b/test/eetcd_lease_SUITE.erl
@@ -66,7 +66,7 @@ lease_keepalive_once(_Config) ->
     [#{'ID' := ID} | _] = Leases1,
     timer:sleep(900),
     {ok, _Pid} = eetcd_lease:keep_alive_once(?Name, ID),
-    timer:sleep(NewTTL * 1000 + 200),
+    timer:sleep(NewTTL * 1000 - 300),
     Leases2 = list_leases(?Name),
     ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases2)),
     timer:sleep(2100),

--- a/test/eetcd_lease_SUITE.erl
+++ b/test/eetcd_lease_SUITE.erl
@@ -1,7 +1,8 @@
 -module(eetcd_lease_SUITE).
 
+-include_lib("eunit/include/eunit.hrl").
 
--export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1]).
+-export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
 -export([lease_base/1, lease_timeout/1, lease_keepalive_once/1, lease_keepalive/1, put_with_lease/1]).
 
 -define(Name, ?MODULE).
@@ -20,42 +21,56 @@ init_per_suite(Config) ->
     {ok, _Pid} = eetcd:open(?Name, ["127.0.0.1:2379", "127.0.0.1:2479", "127.0.0.1:2579"]),
     Config.
 
-end_per_suite(_Config) ->
+init_per_testcase(_TestCase, Config) ->
+    revoke_all_leases(?Name),
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    revoke_all_leases(?Name),
+    Config.
+
+end_per_suite(Config) ->
+    revoke_all_leases(?Name),
     eetcd:close(?Name),
     application:stop(eetcd),
-    ok.
+    Config.
 
 lease_base(_Config) ->
-    TTL = 100,
+    TTL = 10,
     {ok, #{'ID' := ID, 'TTL' := TTL}} = eetcd_lease:grant(?Name, TTL),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
+    timer:sleep(200),
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases1)),
     {ok, #{}} = eetcd_lease:revoke(?Name, ID),
-    {ok, #{leases := Leases}} = eetcd_lease:leases(?Name),
-    false = lists:member(#{'ID' => ID}, Leases),
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    ?assertNot(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases2)),
     ok.
 
 lease_timeout(_Config) ->
     TTL = 2,
     {ok, #{'ID' := ID, 'TTL' := NewTTL}} = eetcd_lease:grant(?Name, TTL),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases1)),
     timer:sleep(NewTTL * 1000 + 1000),
-    {ok, #{leases := []}} = eetcd_lease:leases(?Name),
-    
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    ?assertEqual([], Leases2),
+
     {error, {grpc_error, #{'grpc-status' := 5}}} = eetcd_lease:revoke(?Name, ID),
     ok.
 
 lease_keepalive_once(_Config) ->
     TTL = 2,
     {ok, #{'ID' := ID, 'TTL' := NewTTL}} = eetcd_lease:grant(?Name, TTL),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
-    timer:sleep(1000),
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    [#{'ID' := ID} | _] = Leases1,
+    timer:sleep(900),
     {ok, _Pid} = eetcd_lease:keep_alive_once(?Name, ID),
     timer:sleep(NewTTL * 1000 + 200),
-    {ok, #{leases := Leases}} = eetcd_lease:leases(?Name),
-    true = lists:member(#{'ID' => ID}, Leases),
-    timer:sleep(1500),
-    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
-    false = lists:member(#{'ID' => ID}, Leases1),
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases2)),
+    timer:sleep(2100),
+    {ok, #{leases := Leases3}} = eetcd_lease:leases(?Name),
+    ?assertNot(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases3)),
     {error, {grpc_error, #{'grpc-status' := 5}}} = eetcd_lease:revoke(?Name, ID),
     ok.
 
@@ -64,12 +79,16 @@ lease_keepalive(_Config) ->
     {ok, #{'ID' := ID, 'TTL' := TTL}}
         = eetcd_lease:grant(?Name, TTL),
     {ok, _Pid} = eetcd_lease:keep_alive(?Name, ID),
-    
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
+
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    [#{'ID' := ID} | _] = Leases1,
     timer:sleep(10000),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
-    
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    [#{'ID' := ID} | _ ] = Leases2,
+
     {ok, #{}} = eetcd_lease:revoke(?Name, ID),
+    {ok, #{leases := Leases3}} = eetcd_lease:leases(?Name),
+    ?assertNot(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases3)),
     ok.
 
 put_with_lease(_Config) ->
@@ -79,23 +98,29 @@ put_with_lease(_Config) ->
     {ok, #{'ID' := ID, 'TTL' := TTL}}
         = eetcd_lease:grant(?Name, TTL),
     {ok, _Pid} = eetcd_lease:keep_alive(?Name, ID),
-    
+
     Req = eetcd_kv:with_lease(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value), ID),
     eetcd_kv:put(Req),
-    
-    timer:sleep(10000),
-    
+
+    timer:sleep(TTL * 1000 * 2),
+
     {ok, #{kvs := [#{key := Key, value := Value, lease := ID}]}}
         = eetcd_kv:get(eetcd_kv:with_key(eetcd_kv:new(?Name), Key)),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
-    
+    {ok, #{leases := [#{'ID' := ID} | _]}} = eetcd_lease:leases(?Name),
+
     {ok, #{}} = eetcd_lease:revoke(?Name, ID),
-    
+
     {ok, #{kvs := [], more := false, count := 0}}
         = eetcd_kv:get(eetcd_kv:with_key(eetcd_kv:new(?Name), Key)),
-    
+
     ok.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+revoke_all_leases(?Name) ->
+    {ok, #{leases := Leases}} = eetcd_lease:leases(?Name),
+    lists:foreach(fun(#{'ID' := ID}) ->
+      eetcd_lease:revoke(?Name, ID)
+    end, Leases).

--- a/test/eetcd_lease_SUITE.erl
+++ b/test/eetcd_lease_SUITE.erl
@@ -18,7 +18,8 @@ groups() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(eetcd),
-    {ok, _Pid} = eetcd:open(?Name, ["127.0.0.1:2379", "127.0.0.1:2479", "127.0.0.1:2579"]),
+    {ok, _Pid} = eetcd:open(?Name, ["127.0.0.1:2379", "127.0.0.1:2479", "127.0.0.1:2579"],
+                            [{mode, random}], tcp, []),
     Config.
 
 init_per_testcase(_TestCase, Config) ->


### PR DESCRIPTION
This cleans up leases before and after test suite runs
and generally attempts to improve stability and clarify
the intent of individual tests.

Unfortunately I still get sporadic failures when I run the suite, say, 10 times in a loop as returned lease list
is occasionally blank. I'm not sure what may be the root cause, it could be that by default etcd's or this client's effective consistency model is not what I expect. In any case, I'd like to be able to run
tests repeatedly against the same cluster so that I can focus on #14 and #16.