### PR TITLE
Correctly compute key range end in eetcd_kv:with_prefix/1

### DIFF
--- a/src/eetcd_data_coercion.erl
+++ b/src/eetcd_data_coercion.erl
@@ -1,0 +1,17 @@
+-module(eetcd_data_coercion).
+
+%% API
+-export([to_list/1, to_binary/1]).
+
+-spec to_list(Val :: integer() | list() | binary() | atom() | map()) -> list().
+to_list(Val) when is_list(Val)    -> Val;
+to_list(Val) when is_map(Val)     -> maps:to_list(Val);
+to_list(Val) when is_atom(Val)    -> atom_to_list(Val);
+to_list(Val) when is_binary(Val)  -> binary_to_list(Val);
+to_list(Val) when is_integer(Val) -> integer_to_list(Val).
+
+-spec to_binary(Val :: binary() | list() | atom() | integer()) -> binary().
+to_binary(Val) when is_list(Val)    -> list_to_binary(Val);
+to_binary(Val) when is_atom(Val)    -> atom_to_binary(Val, utf8);
+to_binary(Val) when is_integer(Val) -> integer_to_binary(Val);
+to_binary(Val)                      -> Val.

--- a/src/eetcd_kv.erl
+++ b/src/eetcd_kv.erl
@@ -381,12 +381,11 @@ get_prefix_range_end(Key) ->
         [] -> ?UNBOUND_RANGE_END;
         List0 when is_list(List0) ->
             Ord = lists:last(List0),
-            case Ord > 255 of
-                true  -> ?UNBOUND_RANGE_END;
-                false ->
-                    NewOrd = Ord + 1,
-                    lists:droplast(List0) ++ [NewOrd]
-            end
+            NewOrd = case Ord > 255 of
+                true  -> Ord;
+                false -> Ord + 1
+            end,
+            lists:droplast(List0) ++ [NewOrd]
     end;
 %% fall back option
 get_prefix_range_end(_) ->

--- a/src/eetcd_kv.erl
+++ b/src/eetcd_kv.erl
@@ -390,7 +390,4 @@ get_prefix_range_end(Key) ->
                     Ord = lists:last(Prefix),
                     lists:droplast(Prefix) ++ [Ord + 1] ++ Suffix
             end
-    end;
-%% fall back option
-get_prefix_range_end(_) ->
-    ?UNBOUND_RANGE_END.
+    end.

--- a/src/eetcd_kv.erl
+++ b/src/eetcd_kv.erl
@@ -19,6 +19,8 @@
     with_first_rev/1, with_last_rev/1, with_first_key/1, with_last_key/1,
     with_top/3, with_prev_kv/1, with_physical/1
 ]).
+%% for tests
+-export([get_prefix_range_end/1]).
 
 %%% @doc Create context for request.
 -spec new(atom()|reference()) -> context().
@@ -43,11 +45,11 @@ with_value(Context, Key) ->
     maps:put(value, Key, Context).
 
 %% @doc Enables `get', `delete' requests to operate
-%% on the keys with matching prefix. For example, `get("foo", with_prefix())'
+%% on the keys with matching prefix. For example, `get(with_prefix(with_key(Ctx, "foo"))'
 %% can return 'foo1', 'foo2', and so on.
 -spec with_prefix(context()) -> context().
-with_prefix(Context) ->
-    with_range_end(Context, "\0").
+with_prefix(#{key := Key} = Context) ->
+    with_range_end(Context, get_prefix_range_end(Key)).
 
 %%  @doc Specifies the range of `get', `delete' requests
 %% to be equal or greater than the key in the argument.
@@ -275,7 +277,7 @@ get(Context) when is_map(Context) -> eetcd_kv_gen:range(Context).
 get(Context, Key) ->
     C0 = new(Context),
     C1 = with_key(C0, Key),
-    eetcd_kv_gen:range(C1).
+    eetcd_kv_gen:range(C1). 
 
 %%% @doc Delete deletes a key, or optionally using eetcd_kv:with_range(End), [Key, End).
 %%% <dl>
@@ -366,3 +368,26 @@ txn(Context, If, Then, Else) ->
     Failure = case is_list(Else) of true -> Else; false -> [Else] end,
     Txn = maps:merge(#{compare => Compare, success => Success, failure => Failure}, C1),
     eetcd_kv_gen:txn(Txn).
+
+
+%%
+%% Implementation
+%%
+
+-define(UNBOUND_RANGE_END, "\0").
+
+get_prefix_range_end(Key) ->
+    case eetcd_data_coercion:to_list(Key) of
+        [] -> ?UNBOUND_RANGE_END;
+        List0 when is_list(List0) ->
+            Ord = lists:last(List0),
+            case Ord > 255 of
+                true  -> ?UNBOUND_RANGE_END;
+                false ->
+                    NewOrd = Ord + 1,
+                    lists:droplast(List0) ++ [NewOrd]
+            end
+    end;
+%% fall back option
+get_prefix_range_end(_) ->
+    ?UNBOUND_RANGE_END.

--- a/test/eetcd_kv_SUITE.erl
+++ b/test/eetcd_kv_SUITE.erl
@@ -4,9 +4,9 @@
 
 -export([put/1, range/1, delete_range/1, txn/1, compact/1]).
 
--define(KEY(K), <<"eetcd_kev", (list_to_binary(K))/binary>>).
+-define(KEY(K), <<"eetcd_key_", (list_to_binary(K))/binary>>).
 
--define(VALUE(V), <<"eetcd_value", (list_to_binary(V))/binary>>).
+-define(VALUE(V), <<"eetcd_value_", (list_to_binary(V))/binary>>).
 
 -define(NAME(C), proplists:get_value(name, C)).
 

--- a/test/eetcd_lease_SUITE.erl
+++ b/test/eetcd_lease_SUITE.erl
@@ -66,7 +66,7 @@ lease_keepalive_once(_Config) ->
     [#{'ID' := ID} | _] = Leases1,
     timer:sleep(900),
     {ok, _Pid} = eetcd_lease:keep_alive_once(?Name, ID),
-    timer:sleep(NewTTL * 1000 + 200),
+    timer:sleep(NewTTL * 1000 - 300),
     Leases2 = list_leases(?Name),
     ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases2)),
     timer:sleep(2100),

--- a/test/eetcd_lease_SUITE.erl
+++ b/test/eetcd_lease_SUITE.erl
@@ -1,7 +1,8 @@
 -module(eetcd_lease_SUITE).
 
+-include_lib("eunit/include/eunit.hrl").
 
--export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1]).
+-export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
 -export([lease_base/1, lease_timeout/1, lease_keepalive_once/1, lease_keepalive/1, put_with_lease/1]).
 
 -define(Name, ?MODULE).
@@ -20,42 +21,56 @@ init_per_suite(Config) ->
     {ok, _Pid} = eetcd:open(?Name, ["127.0.0.1:2379", "127.0.0.1:2479", "127.0.0.1:2579"]),
     Config.
 
-end_per_suite(_Config) ->
+init_per_testcase(_TestCase, Config) ->
+    revoke_all_leases(?Name),
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    revoke_all_leases(?Name),
+    Config.
+
+end_per_suite(Config) ->
+    revoke_all_leases(?Name),
     eetcd:close(?Name),
     application:stop(eetcd),
-    ok.
+    Config.
 
 lease_base(_Config) ->
-    TTL = 100,
+    TTL = 10,
     {ok, #{'ID' := ID, 'TTL' := TTL}} = eetcd_lease:grant(?Name, TTL),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
+    timer:sleep(200),
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases1)),
     {ok, #{}} = eetcd_lease:revoke(?Name, ID),
-    {ok, #{leases := Leases}} = eetcd_lease:leases(?Name),
-    false = lists:member(#{'ID' => ID}, Leases),
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    ?assertNot(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases2)),
     ok.
 
 lease_timeout(_Config) ->
     TTL = 2,
     {ok, #{'ID' := ID, 'TTL' := NewTTL}} = eetcd_lease:grant(?Name, TTL),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases1)),
     timer:sleep(NewTTL * 1000 + 1000),
-    {ok, #{leases := []}} = eetcd_lease:leases(?Name),
-    
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    ?assertEqual([], Leases2),
+
     {error, {grpc_error, #{'grpc-status' := 5}}} = eetcd_lease:revoke(?Name, ID),
     ok.
 
 lease_keepalive_once(_Config) ->
     TTL = 2,
     {ok, #{'ID' := ID, 'TTL' := NewTTL}} = eetcd_lease:grant(?Name, TTL),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
-    timer:sleep(1000),
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    [#{'ID' := ID} | _] = Leases1,
+    timer:sleep(900),
     {ok, _Pid} = eetcd_lease:keep_alive_once(?Name, ID),
     timer:sleep(NewTTL * 1000 + 200),
-    {ok, #{leases := Leases}} = eetcd_lease:leases(?Name),
-    true = lists:member(#{'ID' => ID}, Leases),
-    timer:sleep(1500),
-    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
-    false = lists:member(#{'ID' => ID}, Leases1),
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    ?assert(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases2)),
+    timer:sleep(2100),
+    {ok, #{leases := Leases3}} = eetcd_lease:leases(?Name),
+    ?assertNot(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases3)),
     {error, {grpc_error, #{'grpc-status' := 5}}} = eetcd_lease:revoke(?Name, ID),
     ok.
 
@@ -64,12 +79,16 @@ lease_keepalive(_Config) ->
     {ok, #{'ID' := ID, 'TTL' := TTL}}
         = eetcd_lease:grant(?Name, TTL),
     {ok, _Pid} = eetcd_lease:keep_alive(?Name, ID),
-    
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
+
+    {ok, #{leases := Leases1}} = eetcd_lease:leases(?Name),
+    [#{'ID' := ID} | _] = Leases1,
     timer:sleep(10000),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
-    
+    {ok, #{leases := Leases2}} = eetcd_lease:leases(?Name),
+    [#{'ID' := ID} | _ ] = Leases2,
+
     {ok, #{}} = eetcd_lease:revoke(?Name, ID),
+    {ok, #{leases := Leases3}} = eetcd_lease:leases(?Name),
+    ?assertNot(lists:any(fun(#{'ID' := Val}) -> Val =:= ID end, Leases3)),
     ok.
 
 put_with_lease(_Config) ->
@@ -79,23 +98,29 @@ put_with_lease(_Config) ->
     {ok, #{'ID' := ID, 'TTL' := TTL}}
         = eetcd_lease:grant(?Name, TTL),
     {ok, _Pid} = eetcd_lease:keep_alive(?Name, ID),
-    
+
     Req = eetcd_kv:with_lease(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value), ID),
     eetcd_kv:put(Req),
-    
-    timer:sleep(10000),
-    
+
+    timer:sleep(TTL * 1000 * 2),
+
     {ok, #{kvs := [#{key := Key, value := Value, lease := ID}]}}
         = eetcd_kv:get(eetcd_kv:with_key(eetcd_kv:new(?Name), Key)),
-    {ok, #{leases := [#{'ID' := ID}]}} = eetcd_lease:leases(?Name),
-    
+    {ok, #{leases := [#{'ID' := ID} | _]}} = eetcd_lease:leases(?Name),
+
     {ok, #{}} = eetcd_lease:revoke(?Name, ID),
-    
+
     {ok, #{kvs := [], more := false, count := 0}}
         = eetcd_kv:get(eetcd_kv:with_key(eetcd_kv:new(?Name), Key)),
-    
+
     ok.
 
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+revoke_all_leases(?Name) ->
+    {ok, #{leases := Leases}} = eetcd_lease:leases(?Name),
+    lists:foreach(fun(#{'ID' := ID}) ->
+      eetcd_lease:revoke(?Name, ID)
+    end, Leases).

--- a/test/eetcd_lease_SUITE.erl
+++ b/test/eetcd_lease_SUITE.erl
@@ -18,7 +18,8 @@ groups() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(eetcd),
-    {ok, _Pid} = eetcd:open(?Name, ["127.0.0.1:2379", "127.0.0.1:2479", "127.0.0.1:2579"]),
+    {ok, _Pid} = eetcd:open(?Name, ["127.0.0.1:2379", "127.0.0.1:2479", "127.0.0.1:2579"],
+                            [{mode, random}], tcp, []),
     Config.
 
 init_per_testcase(_TestCase, Config) ->


### PR DESCRIPTION
Closes #14 which follows the idea mentioned in https://github.com/etcd-io/etcd/blob/master/etcdserver/etcdserverpb/rpc.proto#L410.

This includes #17, so #17 should be merged so that Git history makes a bit more sense.