### PR TITLE
Update gun to 1.3.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [{i, "./_build/default/plugins/gpb/include"}]}.
 {deps, [
-    {gun, "1.3.2"}
+    {gun, "1.3.3"}
 ]}.
 
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.1.0",
-[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.6.0">>},1},
- {<<"gun">>,{pkg,<<"gun">>,<<"1.3.2">>},0}]}.
+[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.7.3">>},1},
+ {<<"gun">>,{pkg,<<"gun">>,<<"1.3.3">>},0}]}.
 [
 {pkg_hash,[
- {<<"cowlib">>, <<"8AA629F81A0FC189F261DC98A42243FA842625FEEA3C7EC56C48F4CCDB55490F">>},
- {<<"gun">>, <<"542064CBB9F613650B8A8100B3A927505F364FBE198B7A5A112868FF43F3E477">>}]}
+ {<<"cowlib">>, <<"A7FFCD0917E6D50B4D5FB28E9E2085A0CEB3C97DEA310505F7460FF5ED764CE9">>},
+ {<<"gun">>, <<"CF8B51BEB36C22B9C8DF1921E3F2BC4D2B1F68B49AD4FBC64E91875AA14E16B4">>}]}
 ].

--- a/setup_etcd.sh
+++ b/setup_etcd.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-ETCD_VER=v3.3.18
+ETCD_VER=v3.4.12
 
 # choose either URL
 GOOGLE_URL=https://storage.googleapis.com/etcd
 GITHUB_URL=https://github.com/etcd-io/etcd/releases/download
-DOWNLOAD_URL=${GOOGLE_URL}
+DOWNLOAD_URL=${GITHUB_URL}
 
 rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
 rm -rf /tmp/etcd && mkdir -p /tmp/etcd


### PR DESCRIPTION
Also updates etcd version. Tested using Erlang 23.0.3 on Arch Linux

Gun 1.3.3 includes the new erlang.mk version that RabbitMQ requires. eetcd is used by our etcd peer discovery plugin. I'm assuming this change will be released as eetcd 0.3.3

Thanks!