### PR TITLE
Add multiplexing support for watch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,18 +201,18 @@ get_exist_services() ->
     Ctx2 = eetcd_kv:with_prefix(Ctx1),
     Ctx3 = eetcd_kv:with_keys_only(Ctx2),
     {ok, #{header := #{revision := Revision}, kvs := Services}} = eetcd_kv:get(Ctx3),
-    Services =
+    Services1 =
         [begin
              [_, Type, IP, Port] = binary:split(Key, [<<"|">>], [global]),
              {{IP, Port}, Type}
          end || #{key := Key} <- Services],
-    {ok, Services, Revision}.
+    {ok, Services1, Revision}.
 
 watch_services_event(Revision) ->
     ReqInit = eetcd_watch:new(),
     ReqKey = eetcd_watch:with_key(ReqInit, <<"heartbeat:">>),
     ReqPrefix = eetcd_watch:with_prefix(ReqKey),
-    Req = eetcd_watch:with_start_revision(ReqPrefix, Revision),
+    Req = eetcd_watch:with_start_revision(ReqPrefix, Revision + 1),
     eetcd_watch:watch(?NAME, Req).
 
 handle_info(Msg, Conn) ->

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ update_services(#{events := Events}) ->
     ok.
 ```
 
+We can use a single stream for multiplex watches, see [example](/test/eetcd_watch_example.erl).
+
 ##### Election Example
 [Election Example](https://github.com/zhongwencool/eetcd/blob/master/test/eetcd_election_leader_example.erl)
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,14 @@ handle_info(Msg, Conn) ->
         {more, NewConn} ->
             {noreply, NewConn};
         {error, _Reason} ->
-            #{revision := Revision} = Conn,
+            #{watch_ids := Ids} = Conn,
+            %% We expect there is only one watch in the Conn in this example
+            %%
+            %% TODO
+            %% If there are more than one watch (aka multiplexing watch stream),
+            %% this watcher process should keep the corresponding key/prefix to the watch id,
+            %% to retrieve the correct revision of it.
+            [#{revision := Revision}] = maps:values(Ids),
             {ok, NewConn} = watch_services_event(Revision),
             {noreply, NewConn};
         unknown ->

--- a/src/eetcd_watch.erl
+++ b/src/eetcd_watch.erl
@@ -3,13 +3,23 @@
 
 -export_type([watch_conn/0]).
 -type watch_conn() :: #{http2_pid => pid(),
-monitor_ref => reference(),
-stream_ref => reference(),
-unprocessed => binary(),
-revision => integer(), %% Revision is the revision of the KV when the watchResponse is created. For a normal response, the revision should be the same as the last modified revision inside Events.
-compact_revision => integer(), %% CompactRevision is set when the watcher is cancelled due to compaction.
-watch_id => integer(),
-response => router_pb:'Etcd.WatchResponse'()}.
+                        monitor_ref => reference(),
+                        stream_ref => reference(),
+
+                        %% A buffer for incompleted response frame
+                        unprocessed => binary(),
+
+                        %% Revision is the revision of the KV when the watchResponse is created, aka
+                        %% the [Start_Revision](https://etcd.io/docs/v3.5/learning/api/).
+                        watch_ids => #{ integer() =>
+                                        #{
+                                          %% For a normal response, the revision should be the same as the last modified revision inside Events.
+                                          revision => integer(),
+
+                                          %% CompactRevision is set when the watcher is cancelled due to compaction.
+                                          compact_revision => integer()
+                                         }}
+                       }.
 
 %% API
 -export([new/0, with_key/2,
@@ -21,7 +31,7 @@ response => router_pb:'Etcd.WatchResponse'()}.
     with_fragment/1,
     with_progress_notify/1
 ]).
--export([watch/2, watch/3]).
+-export([watch/2, watch/3, watch/4]).
 -export([watch_stream/2]).
 -export([unwatch/2]).
 -export([rev/1]).
@@ -51,6 +61,14 @@ with_prev_kv(Context) ->
 with_fragment(Context) ->
     maps:put(fragment, true, Context).
 
+%% @doc Start revision, an optional revision for where to inclusively begin watching.
+%% If not given, it will stream events following the revision of the watch creation
+%% response header revision.
+%% The entire available event history can be watched starting from the last compaction revision.
+%%
+%% Note that the start revision is inclusive, so for example, if the start revision is 100,
+%% the first event returned will be at revision 100. So in practice, the start revision is better
+%% set to the last **GET** revision + 1 to exclude the previous change before the watch.
 with_start_revision(Context, Rev) ->
     maps:put(start_revision, Rev, Context).
 
@@ -104,7 +122,12 @@ with_range_end(Context, End) ->
 -spec watch(name(), context()) ->
     {ok, watch_conn()} | {error, {stream_error | conn_error | http2_down, term()} | timeout}.
 watch(Name, CreateReq) ->
-    watch(Name, CreateReq, 5000).
+    watch(Name, CreateReq, undefined, 5000).
+
+watch(Name, CreateReq, Timeout) when is_integer(Timeout) ->
+    watch(Name, CreateReq, undefined, Timeout);
+watch(Name, CreateReq, WatchConn) ->
+    watch(Name, CreateReq, WatchConn, 5000).
 
 %% @doc Watch watches for events happening or that have happened. Both input and output are streams;
 %% the input stream is for creating watchers and the output stream sends events.
@@ -119,9 +142,20 @@ watch(Name, CreateReq) ->
 %%
 %%	The returned "id" is the ID of this watcher. It appears as WatchID
 %%  in events that are sent to the created watcher through stream channel.
--spec watch(name(), context(), pos_integer()) ->
+-spec watch(name(), context(), watch_conn() | undefined, pos_integer()) ->
     {ok, watch_conn()} | {error, {stream_error | conn_error | http2_down, term()} | timeout}.
-watch(Name, CreateReq, Timeout) ->
+watch(_Name, CreateReq, #{http2_pid := Gun,
+                          stream_ref := StreamRef,
+                          monitor_ref := MRef} = WatchConn, Timeout)
+  when is_pid(Gun), is_reference(StreamRef), is_reference(MRef) ->
+    watch_reuse_(CreateReq, WatchConn, Timeout);
+watch(Name, CreateReq, undefined, Timeout) ->
+    watch_new_(Name, CreateReq, Timeout).
+
+%% Do watch request with a new watch stream.
+-spec watch_new_(name(), context(), pos_integer()) ->
+    {ok, watch_conn()} | {error, {stream_error | conn_error | http2_down, term()} | timeout}.
+watch_new_(Name, CreateReq, Timeout) ->
     Request = #{request_union => {create_request, CreateReq}},
     {ok, Gun, StreamRef} = eetcd_watch_gen:watch(Name),
     MRef = erlang:monitor(process, Gun),
@@ -144,9 +178,8 @@ watch(Name, CreateReq, Timeout) ->
                             http2_pid => Gun,
                             monitor_ref => MRef,
                             stream_ref => StreamRef,
-                            revision => Rev,
-                            compact_revision => CompactRev,
-                            watch_id => WatchId,
+                            watch_ids => #{ WatchId => #{ revision => Rev,
+                                                          compact_revision => CompactRev}},
                             unprocessed => <<>>
                         }
                     };
@@ -157,6 +190,47 @@ watch(Name, CreateReq, Timeout) ->
         {response, fin, 200, RespHeaders} ->
             erlang:demonitor(MRef, [flush]),
             {error, eetcd_grpc:grpc_status(RespHeaders)};
+        {error, _} = Err2 ->
+            erlang:demonitor(MRef, [flush]),
+            Err2
+    end.
+
+%% Do watch request with the re-used watch stream.
+-spec watch_reuse_(context(), watch_conn(), pos_integer()) ->
+    {ok, watch_conn()} | {error, {stream_error | conn_error | http2_down, term()} | timeout}.
+watch_reuse_(CreateReq, #{http2_pid := Gun,
+                    stream_ref := StreamRef,
+                    monitor_ref := MRef,
+                    watch_ids := Ids} = WatchConn,
+       Timeout) ->
+    Request = #{request_union => {create_request, CreateReq}},
+    eetcd_stream:data(Gun, StreamRef, Request, 'Etcd.WatchRequest', nofin),
+    case eetcd_stream:await(Gun, StreamRef, Timeout, MRef) of
+        {response, fin, 200, RespHeaders} ->
+            erlang:demonitor(MRef, [flush]),
+            {error, eetcd_grpc:grpc_status(RespHeaders)};
+
+        %% Response for the watch request with the existed/re-used watch stream.
+        {data, nofin, Body} ->
+            {ok,
+                #{
+                    created := true,
+                    canceled := false,
+                    compact_revision := CompactRev,
+                    header := #{revision := Rev},
+                    watch_id := WatchId
+                }, <<>>}
+                = eetcd_grpc:decode(identity, Body, 'Etcd.WatchResponse'),
+            {ok,
+                WatchConn#{
+                    http2_pid => Gun,
+                    monitor_ref => MRef,
+                    stream_ref => StreamRef,
+                    watch_ids => Ids#{ WatchId => #{ revision => Rev,
+                                                     compact_revision => CompactRev}},
+                    unprocessed => <<>>
+                }
+            };
         {error, _} = Err2 ->
             erlang:demonitor(MRef, [flush]),
             Err2
@@ -177,7 +251,7 @@ watch(Name, CreateReq, Timeout) ->
     | {error, {grpc_error, stream_error | conn_error | http2_down, term()}} when
     Message :: term().
 
-watch_stream(#{stream_ref := Ref, http2_pid := Pid, unprocessed := Unprocessed} = Conn,
+watch_stream(#{stream_ref := Ref, http2_pid := Pid, unprocessed := Unprocessed, watch_ids := Ids} = Conn,
     {gun_data, Pid, Ref, nofin, Data}) ->
     Bin = <<Unprocessed/binary, Data/binary>>,
     case eetcd_grpc:decode(identity, Bin, 'Etcd.WatchResponse') of
@@ -187,9 +261,8 @@ watch_stream(#{stream_ref := Ref, http2_pid := Pid, unprocessed := Unprocessed} 
                 watch_id := WatchId} = Resp,
             {ok,
                 Conn#{
-                    revision => Rev,
-                    compact_revision => CompactRev,
-                    watch_id => WatchId,
+                    watch_ids => Ids#{ WatchId => #{ revision => Rev,
+                                                     compact_revision => CompactRev}},
                     unprocessed => NewUnprocessed},
                 Resp};
         more -> {more, Conn#{unprocessed => Bin}}
@@ -223,27 +296,32 @@ rev(#{revision := Rev}) -> Rev.
 %% This is a synchronous operation.
 %% Other change events will be returned in OtherEvents when these events arrive between the request and the response.
 -spec unwatch(watch_conn(), Timeout) ->
-    {ok, router_pb:'Etcd.WatchResponse'(), OtherEvents}
-    | {error, {stream_error | conn_error | http2_down, term()} | timeout, OtherEvents} when
+    {ok, Responses, OtherEvents}
+    | {error, {stream_error | conn_error | http2_down, term()} | timeout, Responses, OtherEvents} when
     Timeout :: pos_integer(),
+    Responses :: [router_pb:'Etcd.WatchResponse'()],
     OtherEvents :: [router_pb:'Etcd.WatchResponse'()].
 unwatch(WatchConn, Timeout) ->
     #{
         http2_pid := Gun,
         monitor_ref := MRef,
         stream_ref := StreamRef,
-        watch_id := WatchId,
+        watch_ids := WatchIds,
         unprocessed := Unprocessed
     } = WatchConn,
-    Request = #{request_union => {cancel_request, #{watch_id => WatchId}}},
-    eetcd_stream:data(Gun, StreamRef, Request, 'Etcd.WatchRequest', fin),
-    await_unwatch_resp(Gun, StreamRef, Unprocessed, WatchId, Timeout, MRef, []).
+    await_unwatch_resp(Gun, StreamRef, Unprocessed, maps:keys(WatchIds), Timeout, MRef, [], []).
 
 %%====================================================================
 %% Internal functions
 %%====================================================================
 
-await_unwatch_resp(Gun, StreamRef, Unprocessed, WatchId, Timeout, MRef, Acc) ->
+await_unwatch_resp(_Gun, _StreamRef, _Unprocessed, [], _Timeout, MRef, RespAcc, Acc) ->
+    erlang:demonitor(MRef, [flush]),
+    {ok, lists:reverse(RespAcc), lists:reverse(Acc)};
+await_unwatch_resp(Gun, StreamRef, Unprocessed, [WatchId|Rest], Timeout, MRef, RespAcc, Acc) ->
+    Request = #{request_union => {cancel_request, #{watch_id => WatchId}}},
+    eetcd_stream:data(Gun, StreamRef, Request, 'Etcd.WatchRequest', fin),
+
     case eetcd_stream:await(Gun, StreamRef, Timeout, MRef) of
         {data, nofin, Data} ->
             Bin = <<Unprocessed/binary, Data/binary>>,
@@ -251,14 +329,13 @@ await_unwatch_resp(Gun, StreamRef, Unprocessed, WatchId, Timeout, MRef, Acc) ->
                 {ok, Resp, NewUnprocessed} ->
                     case Resp of
                         #{created := false, watch_id := WatchId, canceled := true} ->
-                            erlang:demonitor(MRef, [flush]),
                             gun:cancel(Gun, StreamRef),
-                            {ok, Resp, lists:reverse(Acc)};
+                            await_unwatch_resp(Gun, StreamRef, Unprocessed, Rest, Timeout, MRef, [Resp|RespAcc], Acc);
                         OtherEvent ->
-                            await_unwatch_resp(Gun, StreamRef, NewUnprocessed, WatchId, Timeout, MRef, [OtherEvent | Acc])
+                            await_unwatch_resp(Gun, StreamRef, NewUnprocessed, [WatchId|Rest], Timeout, MRef, RespAcc, [OtherEvent | Acc])
                     end;
                 more ->
-                    await_unwatch_resp(Gun, StreamRef, Bin, WatchId, Timeout, MRef, Acc)
+                    await_unwatch_resp(Gun, StreamRef, Bin, [WatchId|Rest], Timeout, MRef, RespAcc, Acc)
             end;
-        {error, Reason} -> {error, Reason, lists:reverse(Acc)}
+        {error, Reason} -> {error, Reason, lists:reverse(RespAcc), lists:reverse(Acc)}
     end.

--- a/test/eetcd_watch_SUITE.erl
+++ b/test/eetcd_watch_SUITE.erl
@@ -45,26 +45,26 @@ watch_one_key(_Config) ->
         events := [#{type := 'PUT',
             kv := #{key := Key, value := Value}}]}}
         = eetcd_watch:watch_stream(WatchConn, Message),
-    
+
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value1)),
     Message1 = flush(),
     {ok, Conn1, #{created := false,
         events := [#{type := 'PUT',
             kv := #{key := Key, value := Value1}}]}}
         = eetcd_watch:watch_stream(Conn0, Message1),
-    
+
     eetcd_kv:delete(eetcd_kv:with_key(eetcd_kv:new(?Name), Key)),
     Message2 = flush(),
     {ok, Conn2, #{created := false,
         events := [#{type := 'DELETE',
             kv := #{key := Key, value := <<>>}}]}}
         = eetcd_watch:watch_stream(Conn1, Message2),
-    
+
     {ok, [#{created := false, canceled := true,
         events := []}], []} = eetcd_watch:unwatch(Conn2, Timeout),
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value2)),
     {error, timeout} = flush(),
-    
+
     ok.
 
 watch_multi_keys(_Config) ->
@@ -75,14 +75,14 @@ watch_multi_keys(_Config) ->
     Timeout = 3000,
     WatchReq = eetcd_watch:with_range_end(eetcd_watch:with_key(eetcd_watch:new(), Key), "\0"),
     {ok, WatchConn, _WatchId} = eetcd_watch:watch(?Name, WatchReq, Timeout),
-    
+
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value)),
     Message1 = flush(),
     {ok, Conn1, #{created := false,
         events := [#{type := 'PUT',
             kv := #{key := Key, value := Value}}]}}
         = eetcd_watch:watch_stream(WatchConn, Message1),
-    
+
     Key1 = <<Key/binary, "1">>,
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key1), Value1)),
     Message2 = flush(),
@@ -90,23 +90,23 @@ watch_multi_keys(_Config) ->
         events := [#{type := 'PUT',
             kv := #{key := Key1, value := Value1}}]}}
         = eetcd_watch:watch_stream(Conn1, Message2),
-    
+
     Key2 = <<"1", Key/binary>>,
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key2), Value2)),
     {error, timeout} = flush(),
-    
+
     eetcd_kv:delete(?Name, Key1),
     Message3 = flush(),
     {ok, Conn3, #{created := false,
         events := [#{type := 'DELETE',
             kv := #{key := Key1, value := <<>>}}]}}
         = eetcd_watch:watch_stream(Conn2, Message3),
-    
+
     {ok, [#{created := false, canceled := true,
         events := []}], []} = eetcd_watch:unwatch(Conn3, Timeout),
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value2)),
     {error, timeout} = flush(),
-    
+
     ok.
 
 %% start_revision is an optional revision to watch from (inclusive). No start_revision is "now".
@@ -117,7 +117,7 @@ watch_with_start_revision(_Config) ->
     Ctx = eetcd_kv:new(?Name),
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(Ctx, Key), Value)),
     {ok, #{kvs := [#{mod_revision := Revision}]}} = eetcd_kv:get(eetcd_kv:with_key(Ctx, Key)),
-    
+
     WatchReq = eetcd_watch:with_start_revision(eetcd_watch:with_key(eetcd_watch:new(), Key), Revision),
     {ok, WatchConn, _WatchId} = eetcd_watch:watch(?Name, WatchReq, Timeout),
     Message1 = flush(),
@@ -155,10 +155,10 @@ watch_with_filters(_Config) ->
     Timeout = 3000,
     Ctx = eetcd_kv:new(?Name),
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(Ctx, Key), Value)),
-    
+
     WatchReq = eetcd_watch:with_filter_put(eetcd_watch:with_key(eetcd_watch:new(), Key)),
     {ok, WatchConn, _WatchId} = eetcd_watch:watch(?Name, WatchReq, Timeout),
-    
+
     eetcd_kv:delete(eetcd_kv:with_key(Ctx, Key)),
     Message1 = flush(),
     {ok, Conn1, #{created := false,
@@ -178,7 +178,7 @@ watch_with_prev_kv(_Config) ->
     timer:sleep(200),
     WatchReq = eetcd_watch:with_prev_kv(eetcd_watch:with_key(eetcd_watch:new(), Key)),
     {ok, WatchConn, _WatchId} = eetcd_watch:watch(?Name, WatchReq, Timeout),
-    
+
     eetcd_kv:delete(eetcd_kv:with_key(Ctx, Key)),
     Message1 = flush(),
     {ok, Conn1, #{created := false,
@@ -199,12 +199,12 @@ watch_with_watch_id(_Config) ->
     timer:sleep(200),
     WatchReq1 = eetcd_watch:with_key(eetcd_watch:new(), Key),
     {ok, WatchConn1, _WatchId} = eetcd_watch:watch(?Name, WatchReq1, Timeout),
-    
+
     #{watch_ids := WatchIds} = WatchConn1,
     [WatchId] = maps:keys(WatchIds),
     WatchReq2 = eetcd_watch:with_watch_id(eetcd_watch:with_key(eetcd_watch:new(), Key), WatchId),
     {ok, WatchConn2, _WatchId} = eetcd_watch:watch(?Name, WatchReq2, Timeout),
-    
+
     eetcd_kv:delete(?Name, Key),
     Message1 = flush(),
     Message2 = flush(),

--- a/test/eetcd_watch_SUITE.erl
+++ b/test/eetcd_watch_SUITE.erl
@@ -68,6 +68,9 @@ watch_one_key(_Config) ->
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value2)),
     {error, timeout} = flush(),
 
+    %% Clear test keys
+    eetcd_kv:delete(?Name, Key),
+
     ok.
 
 %% watch multiple keys with one single stream and unwatch them
@@ -185,6 +188,10 @@ watch_multi_keys(_Config) ->
     eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key), Value2)),
     {error, timeout} = flush(),
 
+    %% Clear test keys
+    eetcd_kv:delete(?Name, Key),
+    eetcd_kv:delete(?Name, Key2),
+
     ok.
 
 %% start_revision is an optional revision to watch from (inclusive). No start_revision is "now".
@@ -205,6 +212,10 @@ watch_with_start_revision(_Config) ->
         = eetcd_watch:watch_stream(WatchConn, Message1),
     {ok, [#{created := false, canceled := true,
         events := []}], []} = eetcd_watch:unwatch(Conn1, Timeout),
+
+    %% Clear test keys
+    eetcd_kv:delete(?Name, Key),
+
     ok.
 
 %% progress_notify is set so that the etcd server will periodically send a WatchResponse with no events
@@ -245,6 +256,10 @@ watch_with_filters(_Config) ->
         = eetcd_watch:watch_stream(WatchConn, Message1),
     {ok, [#{created := false, canceled := true,
         events := []}], []} = eetcd_watch:unwatch(Conn1, Timeout),
+
+    %% Clear test keys
+    eetcd_kv:delete(?Name, Key),
+
     ok.
 
 watch_with_prev_kv(_Config) ->
@@ -321,6 +336,10 @@ watch_with_huge_value(_Config) ->
     {ok, Conn} = watch_loop(List, WatchConn, Key),
     {ok, [#{created := false, canceled := true,
         events := []}], []} = eetcd_watch:unwatch(Conn, 5000),
+
+    %% Clear test keys
+    eetcd_kv:delete(?Name, Key),
+
     ok.
 
 watch_loop([], Conn, _) -> {ok, Conn};

--- a/test/eetcd_watch_example.erl
+++ b/test/eetcd_watch_example.erl
@@ -1,0 +1,101 @@
+-module(eetcd_watch_example).
+
+-behaviour(gen_server).
+-define(NAME, watch_example_conn).
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+-define(KEY1, <<"heartbeat:">>).
+-define(KEY2, <<"heartbeat2:">>).
+
+start_link() ->
+    gen_server:start({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    erlang:process_flag(trap_exit, true),
+    Registers = ["127.0.0.1:2379"],
+    {ok, _Pid} = eetcd:open(?NAME, Registers),
+
+    ets:new(?MODULE, [named_table, {read_concurrency, true}, public]),
+
+    {ok, Services, Rev1} = get_exist_services(?KEY1),
+    ets:insert(?MODULE, Services),
+    {ok, Services2, Rev2} = get_exist_services(?KEY2),
+    ets:insert(?MODULE, Services2),
+
+    {ok, Conn1, WatchId1} = watch_services_event_(?KEY1, Rev1 + 1),
+    {ok, Conn2, WatchId2} = watch_services_event_(?KEY2, Rev2 + 1, Conn1),
+    Mapping = #{WatchId1 => {?KEY1, Rev1}, WatchId2 => {?KEY2, Rev2}},
+
+    {ok, {Conn2, Mapping}}.
+
+get_exist_services(KeyPrefix) ->
+    Ctx = eetcd_kv:new(?NAME),
+    Ctx1 = eetcd_kv:with_key(Ctx, KeyPrefix),
+    Ctx2 = eetcd_kv:with_prefix(Ctx1),
+    Ctx3 = eetcd_kv:with_keys_only(Ctx2),
+    {ok, #{header := #{revision := Revision}, kvs := Services}} = eetcd_kv:get(Ctx3),
+    Services1 =
+        [begin
+             [_, Type, IP, Port] = binary:split(Key, [<<"|">>], [global]),
+             {{IP, Port}, Type}
+         end || #{key := Key} <- Services],
+    {ok, Services1, Revision}.
+
+watch_services_event_(Key, Revision) ->
+    watch_services_event_(Key, Revision, undefined).
+
+watch_services_event_(Key, Revision, Conn) ->
+    ReqInit = eetcd_watch:new(),
+    ReqKey = eetcd_watch:with_key(ReqInit, Key),
+    ReqPrefix = eetcd_watch:with_prefix(ReqKey),
+    Req = eetcd_watch:with_start_revision(ReqPrefix, Revision),
+    eetcd_watch:watch(?NAME, Req, Conn).
+
+handle_info(Msg, {#{watch_ids := _WatchIds} = Conn, Mapping} = State) ->
+    case eetcd_watch:watch_stream(Conn, Msg) of
+        {ok, NewConn, WatchEvent} ->
+            io:format("Received changes: ~p~n", [WatchEvent]),
+            update_services(WatchEvent),
+            io:format("ets: ~p~n", [ets:tab2list(?MODULE)]),
+            {noreply, {NewConn, update_revision(Mapping, WatchEvent)}};
+        {more, NewConn} ->
+            {noreply, {NewConn, Mapping}};
+        {error, _Reason} ->
+            {NewConn, Watches} =
+            maps:fold(fun(_WatchId, {Key, Rev}, {Conn0, Acc}) ->
+                          {ok, NewConn0, NewWatchId} = watch_services_event_(Key, Rev, Conn0),
+                          {NewConn0, [{NewWatchId, {Key, Rev}}|Acc]}
+                      end, {undefined, []}, Mapping),
+            {noreply, {NewConn, maps:from_list(Watches)}};
+        unknown ->
+            {noreply, State}
+    end.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    eetcd:close(?NAME),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+update_services(#{events := Events}) ->
+    [begin
+         X = binary:split(Key, [<<"|">>], [global]),
+         [_, Type, IP, Port] = X,
+         case EventType of
+             'PUT' -> ets:insert(?MODULE, {{IP, Port}, Type});
+             'DELETE' -> ets:delete(?MODULE, {IP, Port})
+         end
+     end || #{kv := #{key := Key}, type := EventType} <- Events],
+    ok.
+
+update_revision(Mapping, #{header := #{revision := Rev}, watch_id := WatchId}) ->
+    maps:update_with(WatchId, fun({Key, _}) -> {Key, Rev} end, Mapping).


### PR DESCRIPTION
From [etcdv3 API](https://etcd.io/docs/v3.5/learning/api/#watch-streams):

>  A single watch stream can multiplex many distinct watches by tagging events with per-watch identifiers. This multiplexing helps reducing the memory footprint and connection overhead on the core etcd cluster.

However, this PR introduced **breaking changes** to the return type `eetcd_watch:watch_conn/0` and the `eetcd_watch:unwatch/2` function.

In the meantime, these changes may be lack something. For example, if anything error while `watch_stream/2`, the watcher process should perform a new watch request w/ the revisions saved in the `watch_conn/0`, but the revisions (or other metadata of the watch id) of the watch key was missed. That means the watcher process should keep the mapping for the watch key to watch id.

Or maybe we need some more ergonomic API for watching.