### PR TITLE
Add watcher for eetcd

### DIFF
--- a/src/eetcd_sup.erl
+++ b/src/eetcd_sup.erl
@@ -30,6 +30,7 @@ init([]) ->
     SupFlags = #{strategy => one_for_one, intensity => 1000, period => 10},
     Http2Sup = eetcd_conn_sup,
     LeaserSup = eetcd_lease_sup,
+    Watcher = eetcd_watcher,
     ChildSpecs = [
         #{id => Http2Sup,
             start => {Http2Sup, start_link, []},
@@ -42,6 +43,12 @@ init([]) ->
             restart => permanent,
             shutdown => 5000,
             type => worker,
-            modules => [LeaserSup]}
+            modules => [LeaserSup]},
+        #{id => Watcher,
+            start => {eetcd_watcher, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [Watcher]}
     ],
     {ok, {SupFlags, ChildSpecs}}.

--- a/src/eetcd_watcher.erl
+++ b/src/eetcd_watcher.erl
@@ -1,0 +1,264 @@
+-module(eetcd_watcher).
+
+-include("eetcd.hrl").
+
+%% API
+-define(SERVER, ?MODULE).
+
+-export([start_link/0]).
+
+-export([watch/2, watch/3, watch/4, unwatch/0, unwatch/1, unwatch/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-type watch_req() :: context().
+
+-type watch() :: #{name := name(),
+                   watch_req := watch_req(),
+                   watch_conn := eetcd_watch:watch_conn(),
+                   watch_timeout := timeout(),
+                   receiver := pid(),
+                   retry_times => non_neg_integer()
+                  }.
+
+-type state() :: #{watches := [watch()],
+                   conn_names := [name()],
+                   retry_watch_ms := pos_integer(),
+                   retry_watch_max := infinity | pos_integer(),
+                   retry_tref => reference(),
+                   retry_watches := [watch()]}.
+
+-type reason() :: {stream_error | conn_error | http2_down, any()} | timeout.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Before sending watch request to eetcd_watcher, `WatchRequest' should be constructed firstly.
+-spec watch(name(), context()) -> ok | {error, reason()}.
+watch(Name, WatchReq) ->
+    watch(Name, WatchReq, 3000).
+
+-spec watch(name(), context(), timeout()) -> ok.
+watch(Name, WatchReq, WatchTimeout) ->
+    watch(Name, WatchReq, WatchTimeout, 5000).
+
+-spec watch(name(), context(), timeout(), timeout()) -> ok.
+watch(Name, WatchReq, WatchTimeout, CallTimeout) ->
+    gen_server:call(?SERVER, {watch, Name, WatchReq, WatchTimeout}, CallTimeout).
+
+%% @doc Unwatch all keys
+-spec unwatch() -> ok.
+unwatch() ->
+    unwatch(3000).
+
+-spec unwatch(pos_integer()) -> ok.
+unwatch(UnwatchTimeout) ->
+    unwatch(UnwatchTimeout, 5000).
+
+-spec unwatch(pos_integer(), timeout()) -> ok.
+unwatch(UnwatchTimeout, CallTimeout) ->
+    gen_server:call(?SERVER, {unwatch, UnwatchTimeout}, CallTimeout).
+
+-spec start_link() -> gen:start_ret().
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+-spec init([]) -> {ok, state()}.
+init([]) ->
+    RetryWatchMs = application:get_env(eetcd, retry_watch_ms, 3000),
+    RetryWatchMax = application:get_env(eetcd, retry_watch_max, infinity),
+    {ok, ensure_retry_timer(#{retry_watch_ms => RetryWatchMs,
+                              retry_watch_max => RetryWatchMax,
+                              retry_watches => [],
+                              watches => []})}.
+
+-spec ensure_retry_timer(state()) -> state().
+ensure_retry_timer(State = #{retry_watch_ms := RetryWatchMs}) ->
+    TRef = erlang:start_timer(RetryWatchMs, self(), retry),
+    State#{retry_tref => TRef}.
+
+
+-spec handle_call(Request, {pid(), any()}, state()) ->
+          {reply, ok | {error, reason()}, state()} when
+      Request :: {watch, name(), watch_req(), timeout()}
+               | {error, any()}.
+handle_call({watch, Name, WatchReq = #{key := _Key}, WatchTimeout}, {From, _Any},
+            State = #{watches := Watches}) ->
+    case eetcd_watch:watch(Name, WatchReq, WatchTimeout) of
+        {ok, WatchConn, _WatchId} ->
+            Watch = #{name => Name,
+                      watch_req => WatchReq,
+                      watch_conn => WatchConn,
+                      watch_timeout => WatchTimeout,
+                      receiver => From},
+            {reply, ok, State#{watches => [Watch | Watches]}};
+        {error, Reason} ->
+            {reply, {error, Reason}, State}
+    end;
+handle_call({unwatch, UnwatchTimeout}, _From, State = #{watches := Watches}) ->
+    RemainWatches = lists:foldl(
+                      fun(Watch = #{watch_conn := WatchConn}, Acc) ->
+                              case eetcd_watch:unwatch(WatchConn, UnwatchTimeout) of
+                                  ok -> Acc;
+                                  {error, _Reason} ->
+                                      [Watch | Acc]
+                              end
+                      end, [], Watches),
+    {reply, ok, State#{watches => RemainWatches, retry_watches => []}};
+handle_call(_UnexpecteReq, _From, State) ->
+    {reply, {error, illegal_request}, State}.
+
+-spec handle_cast(any(), state()) -> {noreply, state()}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info({timeout, TRef, retry}, State = #{retry_watches := RetryWatches,
+                                              watches := Watches,
+                                              retry_watch_max := RetryWatchMax,
+                                              retry_tref := TRef}) ->
+    {NewWatches, NewRetryWatches} =
+        lists:foldl(
+          fun (#{retry_times := RetryTimes}, Acc)
+                when RetryTimes >= RetryWatchMax  ->
+                  %% Drop the retry watch when its retry times exceed `RetryWatchMax`
+                  Acc;
+              (RetryWatch = #{name := Name,
+                              watch_req := WatchReq,
+                              watch_timeout := WatchTimeout,
+                              retry_times := RetryTimes},
+               {AccWatches, AccRetryWatches}) ->
+                  case eetcd_watch:watch(Name, WatchReq, WatchTimeout) of
+                      {ok, WatchConn, _WatchId} ->
+                          Watch = from_retry_watch(RetryWatch#{watch_conn => WatchConn}),
+                          {[Watch | AccWatches], AccRetryWatches};
+                      {error, _Reason} ->
+                          {AccWatches, [RetryWatch#{retry_times => RetryTimes + 1} | AccRetryWatches]}
+                  end
+          end, {Watches, []}, RetryWatches),
+    {noreply, ensure_retry_timer(
+                State#{retry_watches => NewRetryWatches,
+                       watches => NewWatches})};
+
+%% handle data received from etcd
+handle_info(Msg = {gun_data, CPid, SRef, nofin, _Data}, State = #{watches := Watches}) ->
+    %% Find the watch connection via pid and stream reference
+    case find_watch_conn(#{http2_pid => CPid, stream_ref => SRef}, Watches) of
+        [] ->
+            {stop, {shutdown, unexpected_data}, State};
+        [Watch = #{watch_conn := WatchConn,
+                   receiver := Receiver,
+                   watch_req := WatchReq}] ->
+            RestWatches = lists:delete(Watch, Watches),
+            NewWatch = case eetcd_watch:watch_stream(WatchConn, Msg) of
+                           {ok, NewWatchConn, #{events := Events,
+                                                header := #{revision := Rev}}} ->
+                               Receiver ! {ok, Events},
+                               NewWatchReq = eetcd_watch:with_start_revision(WatchReq, Rev),
+                               Watch#{watch_conn => NewWatchConn,
+                                      watch_req => NewWatchReq};
+                           {more, NewWatchConn} ->
+                               Watch#{watch_conn => NewWatchConn}
+                       end,
+            {noreply, State#{watches => [NewWatch | RestWatches]}}
+    end;
+
+%% handle gRPC error
+handle_info(Msg = {gun_trailers, CPid, SRef, [{<<"grpc-status">>, _Status},
+                                              {<<"grpc-message">>, _Msg}]},
+            State = #{watches := Watches, retry_watches := RetryWatches}) ->
+    %% Find the watch connection via pid and stream reference
+    case find_watch_conn(#{http2_pid => CPid, stream_ref => SRef}, Watches) of
+        [] ->
+            {stop, {shutdown, unexpected_data}, State};
+        [Watch = #{watch_conn := WatchConn,
+                   receiver := Receiver}] ->
+            Receiver ! {error, grpc_error},
+            eetcd_watch:watch_stream(WatchConn, Msg),
+            {noreply, State#{watches => lists:delete(Watch, Watches),
+                             retry_watches => [into_retry_watch(Watch) | RetryWatches]}}
+    end;
+
+%% handle stream error
+handle_info(Msg = {gun_error, CPid, SRef, _Reason}, State = #{watches := Watches,
+                                                              retry_watches := RetryWatches}) ->
+    %% Find the watch connection via pid and stream reference
+    case find_watch_conn(#{http2_pid => CPid, stream_ref => SRef}, Watches) of
+        [] ->
+            {stop, {shutdown, unexpected_data}, State};
+        [Watch = #{watch_conn := WatchConn,
+                   receiver := Receiver}] ->
+            Receiver ! {error, stream_error},
+            eetcd_watch:watch_stream(WatchConn, Msg),
+            {noreply, State#{watches => lists:delete(Watch, Watches),
+                             retry_watches => [into_retry_watch(Watch) | RetryWatches]}}
+    end;
+
+%% handle gun connection process state error
+handle_info(Msg = {gun_error, Pid, _Reason}, State = #{retry_watches := RetryWatches,
+                                                       watches := Watches}) ->
+    %% Find the watch connection via pid
+    case find_watch_conn(#{http2_pid => Pid}, Watches) of
+        [] ->
+            {stop, {shutdown, unexpected_data}, State};
+        StaleWatches ->
+            [ begin
+                  Receiver ! {error, connection_state_error},
+                  eetcd_watch:watch_stream(WatchConn, Msg)
+              end || #{watch_conn := WatchConn, receiver := Receiver} <- StaleWatches],
+            NewRetryWatches = [into_retry_watch(Watch) || Watch <- StaleWatches] ++ RetryWatches,
+            NewWatches = Watches -- StaleWatches,
+            {noreply, State#{watches => NewWatches, retry_watches => NewRetryWatches}}
+    end;
+
+%% handle gun connection down
+handle_info(Msg = {'DOWN', MRef, process, Pid, _Reason},
+            State = #{watches := Watches, retry_watches := RetryWatches}) ->
+    %% Find the watch connection via pid and monitor reference
+    case find_watch_conn(#{http2_pid => Pid, monitor_ref => MRef}, Watches) of
+        [] ->
+            {stop, {shutdown, unexpected_data}, State};
+        [Watch = #{watch_conn := WatchConn, receiver := Receiver}] ->
+            eetcd_watch:watch_stream(WatchConn, Msg),
+            Receiver ! {error, connection_down},
+            {noreply, State#{watches => lists:delete(Watch, Watches),
+                             retry_watches => [into_retry_watch(Watch) | RetryWatches]}}
+    end;
+
+handle_info(_Unknown, State) ->
+    {noreply, State}.
+
+-spec terminate(any(), state()) -> ok.
+terminate(_Reason, #{watches := Watches}) ->
+    [eetcd_watch:unwatch(WatchConn, 5000) || #{watch_conn := WatchConn} <- Watches],
+    ok.
+
+-spec find_watch_conn(#{http2_pid => pid(),
+                        stream_ref => reference(),
+                        monitor_ref => reference()}, [watch()]) -> [watch()].
+find_watch_conn(#{http2_pid := CPid, stream_ref := SRef}, Watches) ->
+    [Watch || Watch = #{watch_conn := #{http2_pid := Http2Pid,
+                                        stream_ref := StreamRef}} <- Watches,
+              Http2Pid =:= CPid, StreamRef =:= SRef];
+find_watch_conn(#{http2_pid := CPid, monitor_ref := MRef}, Watches) ->
+    [Watch || Watch = #{watch_conn := #{http2_pid := Http2Pid,
+                                        monitor_ref := MonitorRef}} <- Watches,
+              Http2Pid =:= CPid, MonitorRef =:= MRef];
+find_watch_conn(#{http2_pid := CPid}, Watches) ->
+    [Watch || Watch = #{watch_conn := #{http2_pid := Http2Pid}} <- Watches,
+              Http2Pid =:= CPid].
+
+-spec into_retry_watch(watch()) -> watch().
+into_retry_watch(Watch) ->
+    Watch#{retry_times => 0}.
+
+-spec from_retry_watch(watch()) -> watch().
+from_retry_watch(Watch) ->
+    maps:without([retry_times], Watch).
+

--- a/src/eetcd_watcher_sup.erl
+++ b/src/eetcd_watcher_sup.erl
@@ -1,0 +1,33 @@
+%% @private
+-module(eetcd_watcher_sup).
+
+-behaviour(supervisor).
+-include("eetcd.hrl").
+
+%% API
+-export([start_link/0, start_child/2]).
+-export([init/1]).
+
+-spec start_link() -> supervisor:startlink_ret().
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-spec start_child(name(), pos_integer()) -> supervisor:startchild_ret().
+start_child(Name, RetryIntervalMs) ->
+    supervisor:start_child(?MODULE, [Name, RetryIntervalMs]).
+
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    MaxRestarts = 300,
+    MaxSecondsBetweenRestarts = 60,
+    SupFlags = #{strategy => simple_one_for_one,
+                 intensity => MaxRestarts,
+                 period => MaxSecondsBetweenRestarts},
+    Worker = eetcd_watcher,
+    Child  = #{id => Worker,
+               start => {Worker, start_link, []},
+               restart => transient,
+               shutdown => 1000,
+               type => worker,
+               modules => [Worker]},
+    {ok, {SupFlags, [Child]}}.

--- a/test/eetcd_watcher_SUITE.erl
+++ b/test/eetcd_watcher_SUITE.erl
@@ -1,0 +1,110 @@
+-module(eetcd_watcher_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, suite/0, init_per_suite/1, end_per_suite/1]).
+
+-export([watch/1,
+         watch_with_client_disconnected/1]).
+
+-define(Name, ?MODULE).
+
+-define(Endpoints, ["127.0.0.1:2379", "127.0.0.1:2479", "127.0.0.1:2579"]).
+
+suite() ->
+    [{timetrap, {minutes, 2}}].
+
+all() ->
+    [watch, watch_with_client_disconnected].
+
+init_per_suite(Config) ->
+    application:set_env(eetcd, retry_watch_ms, 50),
+    application:ensure_all_started(eetcd),
+    {ok, _Pid} = eetcd:open(?Name, ?Endpoints),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(eetcd).
+
+watch(_Config) ->
+    WatchReq0 = eetcd_watch:new(),
+    WatchEtcdKey = <<"etcd_key">>,
+    EtcdKey1 = <<"etcd_key1">>,
+    WatchReq1 = eetcd_watch:with_key(WatchReq0, WatchEtcdKey),
+    WatchReq2 = eetcd_watch:with_prefix(WatchReq1),
+    eetcd_watcher:watch(?Name, WatchReq2),
+    Value1 = <<"etcd_value1">>,
+    eetcd_kv:put(
+      eetcd_kv:with_value(
+        eetcd_kv:with_key(
+          eetcd_kv:new(?Name), EtcdKey1), Value1)),
+    eetcd_kv:delete(
+      eetcd_kv:with_key(
+        eetcd_kv:new(?Name), EtcdKey1)),
+
+    ?assertMatch([{ok, [#{kv := #{key := <<"etcd_key1">>,
+                                  value := <<"etcd_value1">>}, type := 'PUT'}]},
+                  {ok, [#{kv := #{key := <<"etcd_key1">>}, type := 'DELETE'}]}],
+                 receive_events(2, 3000)),
+
+    eetcd_watcher:unwatch(),
+
+    eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), EtcdKey1), Value1)),
+
+    ?assertEqual([], receive_events(1, 3000)).
+
+watch_with_client_disconnected(_Config) ->
+
+    {ok, _Pid} = eetcd:open(helper, ?Endpoints),
+    Key1 = <<"etcd_key1">>,
+    Key2 = <<"etcd_key2">>,
+    Key3 = <<"etcd_key3">>,
+
+    Watch1 = eetcd_watch:with_key(eetcd_watch:new(), Key1),
+    Watch2 = eetcd_watch:with_key(eetcd_watch:new(), Key2),
+    Watch3 = eetcd_watch:with_key(eetcd_watch:new(), Key3),
+
+    Value1 = <<"etcd_value1">>,
+    Value2 = <<"etcd_value2">>,
+    Value3 = <<"etcd_value3">>,
+
+    eetcd_watcher:watch(helper, Watch1),
+    eetcd_watcher:watch(helper, Watch2),
+    eetcd_watcher:watch(helper, Watch3),
+    %% Simulate the situation that connection down
+    ok = eetcd:close(helper),
+
+    {ok, _} = eetcd:open(helper, ?Endpoints),
+
+    timer:sleep(90),
+    ?assertEqual([{error, connection_down},
+                  {error, connection_down},
+                  {error, connection_down}],
+                 receive_events(3, 50)),
+
+    eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key1), Value1)),
+    eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key2), Value2)),
+    eetcd_kv:put(eetcd_kv:with_value(eetcd_kv:with_key(eetcd_kv:new(?Name), Key3), Value3)),
+
+    ?assertMatch([{ok, [#{kv := #{key := <<"etcd_key1">>,
+                                  value := <<"etcd_value1">>}}]},
+                  {ok, [#{kv := #{key := <<"etcd_key2">>,
+                                  value := <<"etcd_value2">>}}]},
+                  {ok, [#{kv := #{key := <<"etcd_key3">>,
+                                  value := <<"etcd_value3">>}}]}
+                 ], receive_events(3, 50)),
+
+    eetcd_watcher:unwatch(),
+    ok = eetcd:close(helper).
+
+receive_events(Times, Timeout) ->
+    receive_events(Times, Timeout, []).
+
+receive_events(0, _Timeout, Acc) ->
+    lists:reverse(Acc);
+receive_events(Times, Timeout, Acc) ->
+    receive Msg ->
+            receive_events(Times - 1, Timeout, [Msg | Acc])
+    after Timeout ->
+            lists:reverse(Acc)
+    end.


### PR DESCRIPTION
In [quickstart section](https://github.com/zhongwencool/eetcd#quick-start) of README, as a user, we have to write a watcher process to watch keys and process messages from the watching stream.

It is better to provide a default eetcd_watcher to watch keys and receive events from watching streams. 

For example:

```erl
{ok, _Pid} = eetcd:open(eetcd_example_conn, Endpoints),

ReqInit = eetcd_watch:new(),
ReqKey = eetcd_watch:with_key(ReqInit, <<"heartbeat:">>),
ReqPrefix = eetcd_watch:with_prefix(ReqKey),
WatchReq = eetcd_watch:with_start_revision(ReqPrefix, Revision + 1),
eetcd_watcher:watch(eetcd_example_conn, WatchReq, 5000).

eetcd_kv:put(eetcd_example_conn, <<"heartbeat:">>, <<"1">>),
receive
     {ok,[#{kv:= #{key := <<"heartbeat:">>, value := <<"1">>}, type := 'PUT'}]} ->
              ok;
     {error, connection_down} ->
               handle_error(...);
end.

eetcd_watcher:unwatch(eetcd_example_conn).
```