### PR TITLE
Fix resiliency in connect_all mode

### DIFF
--- a/src/eetcd.app.src
+++ b/src/eetcd.app.src
@@ -1,13 +1,13 @@
 {application, eetcd,
     [
         {description, "ETCD V3 client"},
-        {vsn, "0.3.5"},
+        {vsn, "0.3.6"},
         {registered, [eetcd_sup, eetcd_conn_sup, eetcd_lease_sup]},
         {mod, {eetcd_app, []}},
         {applications, [kernel, stdlib, gun]},
         {env, []},
         {modules, []},
-        
+
         {licenses, ["Apache 2.0"]},
         {links, [{"Github", "https://github.com/zhongwencool/eetcd"}]}
     ]

--- a/src/eetcd_conn.erl
+++ b/src/eetcd_conn.erl
@@ -416,7 +416,9 @@ do_check_health(connect_all, Data) ->
                     {Health, [{Host, ?MIN_RECONN} | Freeze]}
             end
           end, {[], Freezes}, Actives),
-        NewFreezes1 = [{H1, P1} || {H1, P1} <- NewFreezes, {H2, P2} <- Members, H1 =:= H2, P1 =:= P2],
+        NewFreezes1 = [{{H1, P1}, RECONN} || {{H1, P1}, RECONN} <- NewFreezes,
+                                             {H2, P2} <- Members,
+                                             H1 =:= H2, P1 =:= P2],
     Data#{active_conns => NewActives, freeze_conns => NewFreezes1};
 do_check_health(random, Data) ->
     #{name := Name, active_conns := ActiveConns} = Data,


### PR DESCRIPTION
The tuple `Freeze` is different from the `Members`, which is the root cause why
reconnect mechanism out of work in `connect_all` mode.

This bug is introduced in #41.