### PR TITLE
Fix next index in retry connect_one

### DIFF
--- a/src/eetcd_conn.erl
+++ b/src/eetcd_conn.erl
@@ -224,7 +224,7 @@ connect_one(Index, Retry, Data, Len) ->
                 {error, Reason} ->
                     ?LOG_WARNING("~p failed to connect ETCD host: ~p ~p",
                         [Name, Host, Reason]),
-                    NewIndex = (Index + 1) rem Len + 1,
+                    NewIndex = Index rem Len + 1,
                     connect_one(NewIndex, Retry - 1, Data, Len)
             end
     end.


### PR DESCRIPTION
The `list` in Erlang is 1-based index, but the `rem` operator is 0-based. If we want to wrap around the next index of the list via `rem` operator, we need to turn it back to 0-based. Or else the next index will skip the next one (step 2).

So the next index will be:

```erlang
%% ZeroBasedIndex = Index - 1,
%% NextZeroBasedIndex = (ZeroBasedIndex + 1 rem Len),
%% NextIndex = NextZeroBasedIndex + 1,

%% NewIndex = (Index -1 + 1) rem Len + 1,
NewIndex = Index rem Len + 1,
```