### PR TITLE
Fix handle gun_down event

### DIFF
--- a/src/eetcd_conn.erl
+++ b/src/eetcd_conn.erl
@@ -145,7 +145,7 @@ handle_event({call, From}, {?flush_token, Gun, Token}, _StateName, Data) ->
     {keep_state, NewData, [{reply, From, NewToken}]};
 handle_event(info, {'DOWN', _GunRef, process, Gun, _Reason}, _StateName, Data) ->
     handle_conn_down(Data, Gun);
-handle_event(info, {gun_down, Gun, http2, _Error, _KilledStreams, _UnprocessedStreams}, _StateName, Data) ->
+handle_event(info, {gun_down, Gun, http2, _Error, _KilledStreams}, _StateName, Data) ->
     handle_conn_down(Data, Gun);
 handle_event(EventType, reconnecting, _StateName, Data)
     when EventType =:= internal orelse EventType =:= info ->


### PR DESCRIPTION
Since gun 2.0 the `gun_down` message no longer has its final element documented as `UnprocessedStreams`.

> ## Changelog
>
> - 2.0: The last element of the message's tuple, `UnprocessedStreams` has been removed.

See:

- https://ninenines.eu/docs/en/gun/2.1/manual/gun_down/#_changelog
- https://ninenines.eu/docs/en/gun/2.1/guide/migrating_from_1.3/